### PR TITLE
Add Vana DataDAO starter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# test
+# Vana DataDAO Web3 Starter
+
+This repository contains a minimal example for building a Web3 project on top of the Vana network for data sovereignty.
+
+The example uses a simple Solidity smart contract (`DataDao.sol`) that allows users to register and retrieve their data on-chain. A sample Hardhat deployment script is provided in `scripts/deploy.js`.
+
+## Prerequisites
+
+- Node.js and npm installed
+- `git` for version control
+
+## Setup
+
+1. Initialize a new npm project:
+
+   ```bash
+   npm init -y
+   ```
+
+2. Install Hardhat and the required dependencies:
+
+   ```bash
+   npm install --save-dev hardhat @nomicfoundation/hardhat-toolbox
+   ```
+
+3. Create a Hardhat project (choose "Create an empty hardhat.config.js"):
+
+   ```bash
+   npx hardhat
+   ```
+
+4. Copy the `contracts/DataDao.sol` and `scripts/deploy.js` files from this repository into your project.
+
+5. Compile the contract:
+
+   ```bash
+   npx hardhat compile
+   ```
+
+6. Deploy the contract to a local Hardhat network:
+
+   ```bash
+   npx hardhat run --network localhost scripts/deploy.js
+   ```
+
+## Next Steps
+
+- Integrate your deployed DataDAO contract with the Vana network to participate in the DataDAO ecosystem.
+- Build a front-end or additional smart contracts depending on your project's needs.
+
+This project provides a starting point for experimenting with user-owned data on the Vana network.

--- a/contracts/DataDao.sol
+++ b/contracts/DataDao.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract DataDao {
+    // Example mapping to store user data on-chain.
+    mapping(address => string) private userData;
+
+    event DataRegistered(address indexed user, string data);
+
+    // Register data for the sender. Only the sender can register their own data.
+    function registerData(string calldata data) external {
+        userData[msg.sender] = data;
+        emit DataRegistered(msg.sender, data);
+    }
+
+    // Retrieve data for a user.
+    function getData(address user) external view returns (string memory) {
+        return userData[user];
+    }
+}

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,16 @@
+// Example Hardhat deployment script for the DataDao contract.
+const hre = require("hardhat");
+
+async function main() {
+  const DataDao = await hre.ethers.getContractFactory("DataDao");
+  const dataDao = await DataDao.deploy();
+
+  await dataDao.deployed();
+
+  console.log("DataDao deployed to:", dataDao.address);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add simple Solidity contract for DataDAO
- provide Hardhat deployment script
- document setup instructions for building on Vana

## Testing
- `node --version`
- `npm --version`
- `npm install --save-dev hardhat` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841cab59dbc8329abdba4f4aa4f10df